### PR TITLE
Fix the parameters of `bleurt_scorer.score`

### DIFF
--- a/utils/eval_utils.py
+++ b/utils/eval_utils.py
@@ -182,7 +182,7 @@ def nlg_string_similarities_intermediates_with_F1(prediction_to_aligned_gold: di
         #    del res['CIDEr']
         rouge_l_score = rouge_metric_max_over_ground_truths(rouge_l, prediction, gold_strings)
         if bleurt_scorer:
-            bleurt_score = bleurt_scorer.score(gold_strings, [prediction], batch_size=1)[0]
+            bleurt_score = bleurt_scorer.score(references=gold_strings, candidates=[prediction], batch_size=1)[0]
         else:
             bleurt_score = -1
         # bleurt_score = max(0.0, min(1.0, unnorm_bleurt_score))


### PR DESCRIPTION
When running `python eval/run_scorer.py --task "task_2" --split dev --prediction_file gts_val.tsv --output_dir ./ --bleurt_checkpoint bleurt-large-512`, I encountered the error below, which goes away after making the change suggested by the error message.

```
INFO:__main__:Scoring the following files: ['gts_val.tsv']
INFO:__main__:***** Scoring predictions in gts_val.tsv *****
INFO:__main__:   Gold data from: data/processed_data/slots/task_2-slots/dev.jsonl
INFO:__main__:   Full output in: ./scores-dev
INFO:tensorflow:Reading checkpoint bleurt-large-512.
INFO:tensorflow:Reading checkpoint bleurt-large-512.
INFO:tensorflow:Config file found, reading.
INFO:tensorflow:Config file found, reading.
INFO:tensorflow:Will load checkpoint bert_custom
INFO:tensorflow:Will load checkpoint bert_custom
INFO:tensorflow:Loads full paths and checks that files exists.
INFO:tensorflow:Loads full paths and checks that files exists.
INFO:tensorflow:... name:bert_custom
INFO:tensorflow:... name:bert_custom
INFO:tensorflow:... vocab_file:vocab.txt
INFO:tensorflow:... vocab_file:vocab.txt
INFO:tensorflow:... bert_config_file:bert_config.json
INFO:tensorflow:... bert_config_file:bert_config.json
INFO:tensorflow:... do_lower_case:True
INFO:tensorflow:... do_lower_case:True
INFO:tensorflow:... max_seq_length:512
INFO:tensorflow:... max_seq_length:512
INFO:tensorflow:Creating BLEURT scorer.
INFO:tensorflow:Creating BLEURT scorer.
INFO:tensorflow:Creating WordPiece tokenizer.
INFO:tensorflow:Creating WordPiece tokenizer.
INFO:tensorflow:WordPiece tokenizer instantiated.
INFO:tensorflow:WordPiece tokenizer instantiated.
INFO:tensorflow:Creating Eager Mode predictor.
INFO:tensorflow:Creating Eager Mode predictor.
INFO:tensorflow:Loading model.
INFO:tensorflow:Loading model.
2021-11-06 23:46:45.221222: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 AVX512F FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2021-11-06 23:46:50.115124: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1525] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 20867 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 3090, pci bus id: 0000:60:00.0, compute capability: 8.6
INFO:tensorflow:BLEURT initialized.
INFO:tensorflow:BLEURT initialized.
0it [00:00, ?it/s]


======================

pred:sent10 & sent12 & sent4 -> hypothesis
gold:sent10 & sent12 & sent4 -> hypothesis; 



======================

Reading predicted proof
step:sent10 & sent12 & sent4 -> hypothesis
step_parts:['sent10 & sent12 & sent4 -> hypothesis']
lhs_ids:['sent10', 'sent12', 'sent4']	 rhs = hypothesis	 all_ancestors={'sent10', 'sent4', 'sent12'}
	 rhs = hypothesis, int_str=the sun rising and setting is the event that occurs once per day
	<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	proof:sent10 & sent12 & sent4 -> hypothesis
	sentences:['sent10 & sent12 & sent4 -> hypothesis']
	inferences:[{'lhs': ['sent10', 'sent12', 'sent4'], 'rhs': 'hypothesis'}]
	int_to_all_ancestors_list:[{'int': 'hypothesis', 'ancestors': ['sent10', 'sent4', 'sent12']}]
	relevant_sentences:{'sent10', 'sent4', 'sent12'}
	id_to_int:{'hypothesis': 'the sun rising and setting is the event that occurs once per day'}



||||||||||||||||||||||

Reading gold proof
step:sent10 & sent12 & sent4 -> hypothesis
step_parts:['sent10 & sent12 & sent4 -> hypothesis']
lhs_ids:['sent10', 'sent12', 'sent4']	 rhs = hypothesis	 all_ancestors={'sent10', 'sent4', 'sent12'}
	 rhs = hypothesis, int_str=the sun rising and setting is the event that occurs once per day
step: 
step_parts:['']
	<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
	proof:sent10 & sent12 & sent4 -> hypothesis; 
	sentences:['sent10 & sent12 & sent4 -> hypothesis']
	inferences:[{'lhs': ['sent10', 'sent12', 'sent4'], 'rhs': 'hypothesis'}]
	int_to_all_ancestors_list:[{'int': 'hypothesis', 'ancestors': ['sent10', 'sent4', 'sent12']}]
	relevant_sentences:{'sent10', 'sent4', 'sent12'}
	id_to_int:{'hypothesis': 'the sun rising and setting is the event that occurs once per day'}
%%%%%%%%%	pred_int_to_gold_int_mapping:{'hypothesis': 'hypothesis'}



++++++++++++++++++++++++++++++++++++
pred_int_to_gold_int_mapping:{'hypothesis': 'hypothesis'}
relevant_sentences_pred:{'sent10', 'sent4', 'sent12'}
relevant_sentences_gold:{'sent10', 'sent4', 'sent12'}
		sentences:['sent10', 'sent12', 'sent4']
		sentences_gold:['sent10', 'sent12', 'sent4']
		sentences:['sent10 & sent12 & sent4 -> hypothesis']
		sentences_gold:['sent10 & sent12 & sent4 -> hypothesis']
0it [00:00, ?it/s]
Traceback (most recent call last):
  File "/n/fs/pvl-multihop/entailment_bank/eval/run_scorer.py", line 432, in <module>
    main(args)
  File "/n/fs/pvl-multihop/entailment_bank/eval/run_scorer.py", line 386, in main
    scores = score_predictions(
  File "/n/fs/pvl-multihop/entailment_bank/eval/run_scorer.py", line 148, in score_predictions
    metrics = score_prediction_whole_proof(pred, gold_by_id[item_id], dataset,
  File "/n/fs/pvl-multihop/entailment_bank/utils/eval_utils.py", line 670, in score_prediction_whole_proof
    res.update(score_aligned_entail_tree_proof(slot, gold_list, angle, gold_json_record=gold,bleurt_scorer=bleurt_scorer))
  File "/n/fs/pvl-multihop/entailment_bank/utils/eval_utils.py", line 541, in score_aligned_entail_tree_proof
    res[angle+'-intermediates'] = nlg_string_similarities_intermediates_with_F1(prediction_to_aligned_gold=prediction_to_aligned_gold,
  File "/n/fs/pvl-multihop/entailment_bank/utils/eval_utils.py", line 185, in nlg_string_similarities_intermediates_with_F1
    bleurt_score = bleurt_scorer.score(gold_strings, [prediction], batch_size=1)[0]
  File "/u/kaiyuy/projects/miniconda3/envs/multihop-reasoning/lib/python3.9/site-packages/bleurt/score.py", line 189, in score
    assert not args, (
AssertionError: The score function does not accept positional arguments. Please specify the name of the arguments explicitly, i.e., `score(references=..., candidates=...`)
```